### PR TITLE
create patient portal endpoint & ui

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1146,6 +1146,11 @@
       "resolved": "https://registry.npmjs.org/@csstools/normalize.css/-/normalize.css-10.1.0.tgz",
       "integrity": "sha512-ij4wRiunFfaJxjB0BdrYHIH8FxBJpOwNPhhAcunlmPdXudL1WQV1qoP9un6JsEBAgQH+7UXyyjh0g7jTxXK6tg=="
     },
+    "@emotion/hash": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz",
+      "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow=="
+    },
     "@hapi/address": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.1.4.tgz",
@@ -1366,6 +1371,86 @@
         "@types/istanbul-lib-coverage": "^2.0.0",
         "@types/istanbul-reports": "^1.1.1",
         "@types/yargs": "^13.0.0"
+      }
+    },
+    "@material-ui/core": {
+      "version": "4.12.4",
+      "resolved": "https://registry.npmjs.org/@material-ui/core/-/core-4.12.4.tgz",
+      "integrity": "sha512-tr7xekNlM9LjA6pagJmL8QCgZXaubWUwkJnoYcMKd4gw/t4XiyvnTkjdGrUVicyB2BsdaAv1tvow45bPM4sSwQ==",
+      "requires": {
+        "@babel/runtime": "^7.4.4",
+        "@material-ui/styles": "^4.11.5",
+        "@material-ui/system": "^4.12.2",
+        "@material-ui/types": "5.1.0",
+        "@material-ui/utils": "^4.11.3",
+        "@types/react-transition-group": "^4.2.0",
+        "clsx": "^1.0.4",
+        "hoist-non-react-statics": "^3.3.2",
+        "popper.js": "1.16.1-lts",
+        "prop-types": "^15.7.2",
+        "react-is": "^16.8.0 || ^17.0.0",
+        "react-transition-group": "^4.4.0"
+      }
+    },
+    "@material-ui/lab": {
+      "version": "4.0.0-alpha.61",
+      "resolved": "https://registry.npmjs.org/@material-ui/lab/-/lab-4.0.0-alpha.61.tgz",
+      "integrity": "sha512-rSzm+XKiNUjKegj8bzt5+pygZeckNLOr+IjykH8sYdVk7dE9y2ZuUSofiMV2bJk3qU+JHwexmw+q0RyNZB9ugg==",
+      "requires": {
+        "@babel/runtime": "^7.4.4",
+        "@material-ui/utils": "^4.11.3",
+        "clsx": "^1.0.4",
+        "prop-types": "^15.7.2",
+        "react-is": "^16.8.0 || ^17.0.0"
+      }
+    },
+    "@material-ui/styles": {
+      "version": "4.11.5",
+      "resolved": "https://registry.npmjs.org/@material-ui/styles/-/styles-4.11.5.tgz",
+      "integrity": "sha512-o/41ot5JJiUsIETME9wVLAJrmIWL3j0R0Bj2kCOLbSfqEkKf0fmaPt+5vtblUh5eXr2S+J/8J3DaCb10+CzPGA==",
+      "requires": {
+        "@babel/runtime": "^7.4.4",
+        "@emotion/hash": "^0.8.0",
+        "@material-ui/types": "5.1.0",
+        "@material-ui/utils": "^4.11.3",
+        "clsx": "^1.0.4",
+        "csstype": "^2.5.2",
+        "hoist-non-react-statics": "^3.3.2",
+        "jss": "^10.5.1",
+        "jss-plugin-camel-case": "^10.5.1",
+        "jss-plugin-default-unit": "^10.5.1",
+        "jss-plugin-global": "^10.5.1",
+        "jss-plugin-nested": "^10.5.1",
+        "jss-plugin-props-sort": "^10.5.1",
+        "jss-plugin-rule-value-function": "^10.5.1",
+        "jss-plugin-vendor-prefixer": "^10.5.1",
+        "prop-types": "^15.7.2"
+      }
+    },
+    "@material-ui/system": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@material-ui/system/-/system-4.12.2.tgz",
+      "integrity": "sha512-6CSKu2MtmiJgcCGf6nBQpM8fLkuB9F55EKfbdTC80NND5wpTmKzwdhLYLH3zL4cLlK0gVaaltW7/wMuyTnN0Lw==",
+      "requires": {
+        "@babel/runtime": "^7.4.4",
+        "@material-ui/utils": "^4.11.3",
+        "csstype": "^2.5.2",
+        "prop-types": "^15.7.2"
+      }
+    },
+    "@material-ui/types": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@material-ui/types/-/types-5.1.0.tgz",
+      "integrity": "sha512-7cqRjrY50b8QzRSYyhSpx4WRw2YuO0KKIGQEVk5J8uoz2BanawykgZGoWEqKm7pVIbzFDN0SpPcVV4IhOFkl8A=="
+    },
+    "@material-ui/utils": {
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/@material-ui/utils/-/utils-4.11.3.tgz",
+      "integrity": "sha512-ZuQPV4rBK/V1j2dIkSSEcH5uT6AaHuKWFfotADHsC0wVL1NLd2WkFCm4ZZbX33iO4ydl6V0GPngKm8HZQ2oujg==",
+      "requires": {
+        "@babel/runtime": "^7.4.4",
+        "prop-types": "^15.7.2",
+        "react-is": "^16.8.0 || ^17.0.0"
       }
     },
     "@mrmlnc/readdir-enhanced": {
@@ -1673,10 +1758,45 @@
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA=="
     },
+    "@types/prop-types": {
+      "version": "15.7.5",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
+      "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w=="
+    },
     "@types/q": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.5.tgz",
       "integrity": "sha512-L28j2FcJfSZOnL1WBjDYp2vUHCeIFlyYI/53EwD/rKUBQ7MtUUfbQWiyKJGpcnv4/WgrhWsFKrcPstcAt/J0tQ=="
+    },
+    "@types/react": {
+      "version": "18.0.15",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.15.tgz",
+      "integrity": "sha512-iz3BtLuIYH1uWdsv6wXYdhozhqj20oD4/Hk2DNXIn1kFsmp9x8d9QB6FnPhfkbhd2PgEONt9Q1x/ebkwjfFLow==",
+      "requires": {
+        "@types/prop-types": "*",
+        "@types/scheduler": "*",
+        "csstype": "^3.0.2"
+      },
+      "dependencies": {
+        "csstype": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.0.tgz",
+          "integrity": "sha512-uX1KG+x9h5hIJsaKR9xHUeUraxf8IODOwq9JLNPq6BwB04a/xgpq3rcx47l5BZu5zBPlgD342tdke3Hom/nJRA=="
+        }
+      }
+    },
+    "@types/react-transition-group": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.5.tgz",
+      "integrity": "sha512-juKD/eiSM3/xZYzjuzH6ZwpP+/lejltmiS3QEzV/vmb/Q8+HfDmxu+Baga8UEMGBqV88Nbg4l2hY/K2DkyaLLA==",
+      "requires": {
+        "@types/react": "*"
+      }
+    },
+    "@types/scheduler": {
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
+      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew=="
     },
     "@types/stack-utils": {
       "version": "1.0.1",
@@ -3716,6 +3836,11 @@
         "mimic-response": "^1.0.0"
       }
     },
+    "clsx": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg=="
+    },
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -4280,6 +4405,15 @@
         }
       }
     },
+    "css-vendor": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/css-vendor/-/css-vendor-2.0.8.tgz",
+      "integrity": "sha512-x9Aq0XTInxrkuFeHKbYC7zWY8ai7qJ04Kxd9MnvbC1uO5DagxoHQjm4JvG+vCdXOoFtCjbL2XSZfxmoYa9uQVQ==",
+      "requires": {
+        "@babel/runtime": "^7.8.3",
+        "is-in-browser": "^1.0.2"
+      }
+    },
     "css-what": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-5.1.0.tgz",
@@ -4443,6 +4577,11 @@
       "requires": {
         "cssom": "0.3.x"
       }
+    },
+    "csstype": {
+      "version": "2.6.20",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.20.tgz",
+      "integrity": "sha512-/WwNkdXfckNgw6S5R125rrW8ez139lBHWouiBvX8dfMFtcn6V81REDqnH7+CRpRipfYlyU1CmOnOxrmGcFOjeA=="
     },
     "cyclist": {
       "version": "1.0.1",
@@ -4765,6 +4904,22 @@
       "integrity": "sha512-gd3ypIPfOMr9h5jIKq8E3sHOTCjeirnl0WK5ZdS1AW0Odt0b1PaWaHdJ4Qk4klv+YB9aJBS7mESXjFoDQPu6DA==",
       "requires": {
         "utila": "~0.4"
+      }
+    },
+    "dom-helpers": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+      "requires": {
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
+      },
+      "dependencies": {
+        "csstype": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.0.tgz",
+          "integrity": "sha512-uX1KG+x9h5hIJsaKR9xHUeUraxf8IODOwq9JLNPq6BwB04a/xgpq3rcx47l5BZu5zBPlgD342tdke3Hom/nJRA=="
+        }
       }
     },
     "dom-serializer": {
@@ -6532,6 +6687,14 @@
       "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.12.0.tgz",
       "integrity": "sha1-5tnb5Xy+/mB1HwKvM2GVhwyQwB4="
     },
+    "history": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/history/-/history-5.3.0.tgz",
+      "integrity": "sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==",
+      "requires": {
+        "@babel/runtime": "^7.7.6"
+      }
+    },
     "hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -6540,6 +6703,14 @@
         "hash.js": "^1.0.3",
         "minimalistic-assert": "^1.0.0",
         "minimalistic-crypto-utils": "^1.0.1"
+      }
+    },
+    "hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "requires": {
+        "react-is": "^16.7.0"
       }
     },
     "hosted-git-info": {
@@ -6694,6 +6865,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
       "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM="
+    },
+    "hyphenate-style-name": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.4.tgz",
+      "integrity": "sha512-ygGZLjmXfPHj+ZWh6LwbC37l43MhfztxetbFCoYTM2VjkIUpeHgSNn7QIyVFj7YQ1Wl9Cbw5sholVJPzWvC2MQ=="
     },
     "iconv-lite": {
       "version": "0.4.24",
@@ -7193,6 +7369,11 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.4.tgz",
       "integrity": "sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw=="
+    },
+    "is-in-browser": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/is-in-browser/-/is-in-browser-1.1.3.tgz",
+      "integrity": "sha512-FeXIBgG/CPGd/WUxuEyvgGTEfwiG9Z4EKGxjNMRqviiIIfsmgrpnHLffEDdwUHqNva1VEW91o3xBT/m8Elgl9g=="
     },
     "is-installed-globally": {
       "version": "0.4.0",
@@ -8404,6 +8585,91 @@
       "version": "10.2.0",
       "resolved": "https://registry.npmjs.org/jsrsasign/-/jsrsasign-10.2.0.tgz",
       "integrity": "sha512-khMrV/10U02DRzmXhjuLQjddUF39GHndaJZ/3YiiKkbyEl1T5M6EQF9nQUq0DFVCHusmd/jl8TWl4mWt+1L5hg=="
+    },
+    "jss": {
+      "version": "10.9.0",
+      "resolved": "https://registry.npmjs.org/jss/-/jss-10.9.0.tgz",
+      "integrity": "sha512-YpzpreB6kUunQBbrlArlsMpXYyndt9JATbt95tajx0t4MTJJcCJdd4hdNpHmOIDiUJrF/oX5wtVFrS3uofWfGw==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "csstype": "^3.0.2",
+        "is-in-browser": "^1.1.3",
+        "tiny-warning": "^1.0.2"
+      },
+      "dependencies": {
+        "csstype": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.0.tgz",
+          "integrity": "sha512-uX1KG+x9h5hIJsaKR9xHUeUraxf8IODOwq9JLNPq6BwB04a/xgpq3rcx47l5BZu5zBPlgD342tdke3Hom/nJRA=="
+        }
+      }
+    },
+    "jss-plugin-camel-case": {
+      "version": "10.9.0",
+      "resolved": "https://registry.npmjs.org/jss-plugin-camel-case/-/jss-plugin-camel-case-10.9.0.tgz",
+      "integrity": "sha512-UH6uPpnDk413/r/2Olmw4+y54yEF2lRIV8XIZyuYpgPYTITLlPOsq6XB9qeqv+75SQSg3KLocq5jUBXW8qWWww==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "hyphenate-style-name": "^1.0.3",
+        "jss": "10.9.0"
+      }
+    },
+    "jss-plugin-default-unit": {
+      "version": "10.9.0",
+      "resolved": "https://registry.npmjs.org/jss-plugin-default-unit/-/jss-plugin-default-unit-10.9.0.tgz",
+      "integrity": "sha512-7Ju4Q9wJ/MZPsxfu4T84mzdn7pLHWeqoGd/D8O3eDNNJ93Xc8PxnLmV8s8ZPNRYkLdxZqKtm1nPQ0BM4JRlq2w==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "jss": "10.9.0"
+      }
+    },
+    "jss-plugin-global": {
+      "version": "10.9.0",
+      "resolved": "https://registry.npmjs.org/jss-plugin-global/-/jss-plugin-global-10.9.0.tgz",
+      "integrity": "sha512-4G8PHNJ0x6nwAFsEzcuVDiBlyMsj2y3VjmFAx/uHk/R/gzJV+yRHICjT4MKGGu1cJq2hfowFWCyrr/Gg37FbgQ==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "jss": "10.9.0"
+      }
+    },
+    "jss-plugin-nested": {
+      "version": "10.9.0",
+      "resolved": "https://registry.npmjs.org/jss-plugin-nested/-/jss-plugin-nested-10.9.0.tgz",
+      "integrity": "sha512-2UJnDrfCZpMYcpPYR16oZB7VAC6b/1QLsRiAutOt7wJaaqwCBvNsosLEu/fUyKNQNGdvg2PPJFDO5AX7dwxtoA==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "jss": "10.9.0",
+        "tiny-warning": "^1.0.2"
+      }
+    },
+    "jss-plugin-props-sort": {
+      "version": "10.9.0",
+      "resolved": "https://registry.npmjs.org/jss-plugin-props-sort/-/jss-plugin-props-sort-10.9.0.tgz",
+      "integrity": "sha512-7A76HI8bzwqrsMOJTWKx/uD5v+U8piLnp5bvru7g/3ZEQOu1+PjHvv7bFdNO3DwNPC9oM0a//KwIJsIcDCjDzw==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "jss": "10.9.0"
+      }
+    },
+    "jss-plugin-rule-value-function": {
+      "version": "10.9.0",
+      "resolved": "https://registry.npmjs.org/jss-plugin-rule-value-function/-/jss-plugin-rule-value-function-10.9.0.tgz",
+      "integrity": "sha512-IHJv6YrEf8pRzkY207cPmdbBstBaE+z8pazhPShfz0tZSDtRdQua5jjg6NMz3IbTasVx9FdnmptxPqSWL5tyJg==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "jss": "10.9.0",
+        "tiny-warning": "^1.0.2"
+      }
+    },
+    "jss-plugin-vendor-prefixer": {
+      "version": "10.9.0",
+      "resolved": "https://registry.npmjs.org/jss-plugin-vendor-prefixer/-/jss-plugin-vendor-prefixer-10.9.0.tgz",
+      "integrity": "sha512-MbvsaXP7iiVdYVSEoi+blrW+AYnTDvHTW6I6zqi7JcwXdc6I9Kbm234nEblayhF38EftoenbM+5218pidmC5gA==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "css-vendor": "^2.0.8",
+        "jss": "10.9.0"
+      }
     },
     "jsx-ast-utils": {
       "version": "2.4.1",
@@ -10171,6 +10437,11 @@
         "ts-pnp": "^1.1.6"
       }
     },
+    "popper.js": {
+      "version": "1.16.1-lts",
+      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1-lts.tgz",
+      "integrity": "sha512-Kjw8nKRl1m+VrSFCoVGPph93W/qrSO7ZkqPpTf7F4bk/sqcfWK019dWBUpE/fBOsOQY1dks/Bmcbfn1heM/IsA=="
+    },
     "portfinder": {
       "version": "1.0.28",
       "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.28.tgz",
@@ -11736,6 +12007,23 @@
         "xtend": "^4.0.1"
       }
     },
+    "react-router": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.3.0.tgz",
+      "integrity": "sha512-7Wh1DzVQ+tlFjkeo+ujvjSqSJmkt1+8JO+T5xklPlgrh70y7ogx75ODRW0ThWhY7S+6yEDks8TYrtQe/aoboBQ==",
+      "requires": {
+        "history": "^5.2.0"
+      }
+    },
+    "react-router-dom": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.3.0.tgz",
+      "integrity": "sha512-uaJj7LKytRxZNQV8+RbzJWnJ8K2nPsOOEuX7aQstlMZKQT0164C+X2w6bnkqU3sjtLvpd5ojrezAyfZ1+0sStw==",
+      "requires": {
+        "history": "^5.2.0",
+        "react-router": "6.3.0"
+      }
+    },
     "react-scripts": {
       "version": "3.4.4",
       "resolved": "https://registry.npmjs.org/react-scripts/-/react-scripts-3.4.4.tgz",
@@ -11846,6 +12134,17 @@
         "lowlight": "~1.9.1",
         "prismjs": "^1.8.4",
         "refractor": "^2.4.1"
+      }
+    },
+    "react-transition-group": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.2.tgz",
+      "integrity": "sha512-/RNYfRAMlZwDSr6z4zNKV6xu53/e2BuaBbGhbyYIXTrmgu/bGHzmqOs7mJSJBHy9Ud+ApHx3QjrkKSp1pxvlFg==",
+      "requires": {
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2"
       }
     },
     "read-pkg": {
@@ -14098,6 +14397,11 @@
       "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
       "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
       "optional": true
+    },
+    "tiny-warning": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
+      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
     },
     "tmp": {
       "version": "0.0.33",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "private": true,
   "homepage": "http://localhost:8080",
   "dependencies": {
+    "@material-ui/core": "^4.12.4",
+    "@material-ui/lab": "^4.0.0-alpha.61",
     "axios": "^0.18.0",
     "base64url": "^3.0.0",
     "classnames": "^2.2.6",
@@ -16,6 +18,7 @@
     "react-dom": "^16.13.1",
     "react-loader-spinner": "^2.1.0",
     "react-markdown": "^4.3.1",
+    "react-router-dom": "^6.3.0",
     "react-scripts": "^3.4.1",
     "sass": "^1.32.8",
     "semantic-ui-react": "^0.82.3",

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -1,11 +1,25 @@
 import React, {Component} from 'react';
+import { BrowserRouter as Router, Routes, Route}
+    from 'react-router-dom';
 import RequestBuilder from '../containers/RequestBuilder';
+import PatientPortal from '../containers/PatientPortal';
+import theme from '../containers/styles/theme';
+import { ThemeProvider } from '@material-ui/core/styles';
+
 export default class App extends Component {
     render() {
         return (
-            <div>
-                <RequestBuilder />
-            </div>
+                <Router>
+                    <Routes>
+                        <Route exact path='/' exact element={<RequestBuilder />} />
+                        
+                        <Route exact path='/patient-portal' element={
+                        <ThemeProvider theme={theme}>
+                            <PatientPortal />
+                        </ThemeProvider>} />
+
+                    </Routes>
+                </Router>
         );
     }
 }

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -11,7 +11,7 @@ export default class App extends Component {
         return (
                 <Router>
                     <Routes>
-                        <Route exact path='/' exact element={<RequestBuilder />} />
+                        <Route path='/' exact element={<RequestBuilder />} />
                         
                         <Route exact path='/patient-portal' element={
                         <ThemeProvider theme={theme}>

--- a/src/components/Auth/Alert.jsx
+++ b/src/components/Auth/Alert.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { Snackbar } from '@material-ui/core';
+import { Alert as MuiAlert } from '@material-ui/lab';
+import PropTypes from 'prop-types';
+
+function Alert(props) {
+  const { message, handleClose } = props;
+
+  return (
+    <Snackbar
+      open={message !== null}
+      autoHideDuration={6000}
+      onClose={handleClose}
+      anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
+    >
+      <MuiAlert onClose={handleClose} severity="error">
+        {message}
+      </MuiAlert>
+    </Snackbar>
+  );
+}
+
+Alert.propTypes = {
+  message: PropTypes.string.isRequired,
+  handleClose: PropTypes.func.isRequired
+};
+
+export default Alert;

--- a/src/components/Auth/Alert.jsx
+++ b/src/components/Auth/Alert.jsx
@@ -21,7 +21,7 @@ function Alert(props) {
 }
 
 Alert.propTypes = {
-  message: PropTypes.string.isRequired,
+  message: PropTypes.string,
   handleClose: PropTypes.func.isRequired
 };
 

--- a/src/components/Auth/Login.jsx
+++ b/src/components/Auth/Login.jsx
@@ -9,28 +9,7 @@ const Login = (props) => {
   const [message, setMessage] = useState(null);
   const [username, _setUsername] = useState('');
   const [password, _setPassword] = useState('');
-  const handleClose = useCallback(() => setMessage(null));
-
-  useEffect(() => {
-    const listener = event => {
-      if (event.code === 'Enter' || event.code === 'NumpadEnter') {
-        event.preventDefault();
-        onSubmit();
-      }
-    };
-    document.addEventListener('keydown', listener);
-    return () => {
-      document.removeEventListener('keydown', listener);
-    };
-  }, [username, password]);
-
-  const setUsername = useCallback(event => {
-    _setUsername(event.target.value);
-  });
-
-  const setPassword = useCallback(event => {
-    _setPassword(event.target.value);
-  });
+  const handleClose = () => setMessage(null);
 
   const onSubmit = useCallback(() => {
     if (username && password) {
@@ -53,7 +32,30 @@ const Login = (props) => {
           console.error(err);
         });
     }
-  }, [username, password]);
+  }, [username, password, props]);
+
+  useEffect(() => {
+    const listener = event => {
+      if (event.code === 'Enter' || event.code === 'NumpadEnter') {
+        event.preventDefault();
+        onSubmit();
+      }
+    };
+    document.addEventListener('keydown', listener);
+    return () => {
+      document.removeEventListener('keydown', listener);
+    };
+  }, [username, password, onSubmit]);
+
+  const setUsername = (event => {
+    _setUsername(event.target.value);
+  });
+
+  const setPassword = (event => {
+    _setPassword(event.target.value);
+  });
+
+ 
 
   return (
     <div className={classes.background}>

--- a/src/components/Auth/Login.jsx
+++ b/src/components/Auth/Login.jsx
@@ -1,0 +1,123 @@
+import React, { memo, useCallback, useState, useEffect } from 'react';
+import { TextField, Button } from '@material-ui/core';
+import Alert from './Alert';
+import axios from 'axios';
+import useStyles from './styles';
+import config from '../../properties.json';
+const Login = (props) => {
+  const classes = useStyles();
+  const [message, setMessage] = useState(null);
+  const [username, _setUsername] = useState('');
+  const [password, _setPassword] = useState('');
+  const handleClose = useCallback(() => setMessage(null));
+
+  useEffect(() => {
+    const listener = event => {
+      if (event.code === 'Enter' || event.code === 'NumpadEnter') {
+        event.preventDefault();
+        onSubmit();
+      }
+    };
+    document.addEventListener('keydown', listener);
+    return () => {
+      document.removeEventListener('keydown', listener);
+    };
+  }, [username, password]);
+
+  const setUsername = useCallback(event => {
+    _setUsername(event.target.value);
+  });
+
+  const setPassword = useCallback(event => {
+    _setPassword(event.target.value);
+  });
+
+  const onSubmit = useCallback(() => {
+    if (username && password) {
+      const params = new URLSearchParams();
+      params.append('username', username);
+      params.append('password', password);
+      params.append('grant_type', 'password');
+      params.append('client_id', config.client);
+      axios
+        .post(
+          `${config.auth}/realms/${config.realm}/protocol/openid-connect/token`,
+          params,
+          { withCredentials: true }
+        )
+        .then((result) => {
+          props.tokenCallback(result.data.access_token);
+        })
+        .catch(err => {
+          setMessage('Unable to Login');
+          console.error(err);
+        });
+    }
+  }, [username, password]);
+
+  return (
+    <div className={classes.background}>
+      <Alert message={message} handleClose={handleClose} />
+
+      <div className={`${classes.loginContent} ${classes.formFont}`}>
+        <div className={classes.loginHeader}>Log in.</div>
+        <div className={classes.loginSubheader}>Log in to view your patient records.</div>
+        <form noValidate autoComplete="off" className={classes.formFont}>
+          <TextField
+            classes={{
+              root: classes.loginInput
+            }}
+            InputProps={{
+              classes: {
+                input: classes.resize
+              }
+            }}
+            InputLabelProps={{
+              classes: {
+                root: classes.resize
+              }
+            }}
+            value={username}
+            onChange={setUsername}
+            label="Username"
+          />
+          <TextField
+            classes={{
+              root: `${classes.passwordField} ${classes.loginInput}`
+            }}
+            InputProps={{
+              classes: {
+                input: classes.resize
+              }
+            }}
+            InputLabelProps={{
+              classes: {
+                root: classes.resize
+              }
+            }}
+            type="password"
+            label="Password"
+            value={password}
+            onChange={setPassword}
+          />
+          {/* <div className={`${classes.loginPersistance} ${classes.formFont}`}>
+            <input type="checkbox" className={classes.loginCheckbox} />
+            <span className={classes.loginCheckboxText}>Keep me logged in</span>
+          </div> */}
+          <Button
+            variant="contained"
+            color="secondary"
+            disableElevation
+            classes={{ root: classes.loginButton, label: classes.formFont }}
+            onClick={onSubmit}
+          >
+            Log In
+          </Button>
+          <div className={classes.passwordForget}>Forgot password?</div>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default memo(Login);

--- a/src/components/Auth/styles.jsx
+++ b/src/components/Auth/styles.jsx
@@ -1,0 +1,89 @@
+import { makeStyles } from '@material-ui/core/styles';
+export default makeStyles(
+  theme => ({
+    background: {
+      backgroundColor: theme.palette.common.offWhite,
+      height: '100vh'
+    },
+    formFont: {
+      fontFamily: '"Gill Sans", sans-serif'
+    },
+    loginButton: {
+      width: '460px',
+      marginTop: '20px',
+      height: '90px',
+      color: theme.palette.common.white,
+      fontSize: '32px',
+      textTransform: 'none',
+      fontFamily: 'inherit',
+      fontWeight: 200
+    },
+    loginContent: {
+      width: '600px',
+      height: '700px',
+      boxShadow: '0 4px 4px rgba(0, 0, 0, 0.10)',
+      backgroundColor: theme.palette.common.white,
+      margin: '40px auto',
+      paddingLeft: '75px',
+      paddingTop: '90px',
+      textAlign: 'left'
+    },
+    loginHeader: {
+      fontSize: '36px',
+      fontWeight: 600,
+      width: '100%',
+      color: theme.palette.common.grayDark,
+      fontFamily: 'inherit'
+    },
+    loginInput: {
+      display: 'block',
+      fontFamily: 'inherit'
+    },
+    loginPersistance: {
+      display: 'flex',
+      lineHeight: '144px'
+    },
+    loginCheckbox: {
+      height: '24px',
+      width: '24px',
+      margin: '60px 0px 15px 0px'
+    },
+    loginCheckboxText: {
+      fontWeight: 100,
+      fontSize: '24px',
+      marginLeft: '20px',
+      color: theme.palette.common.grayLightText,
+      fontFamily: 'inherit'
+    },
+    loginSubheader: {
+      fontSize: '24px',
+      textAlign: 'left',
+      fontWeight: 100,
+      color: theme.palette.common.grayLightText,
+      marginTop: '20px',
+      fontFamily: 'inherit'
+    },
+    passwordField: {
+      marginTop: '30px'
+    },
+    passwordForget: {
+      float: 'right',
+      color: theme.palette.common.red,
+      margin: '10px 70px 0px 0px',
+      fontSize: '24px',
+      fontFamily: 'inherit',
+      cursor: 'pointer'
+    },
+    resize: {
+      display: 'block',
+      marginTop: '30px',
+      marginBottom: '5px',
+      fontSize: '20px',
+      fontWeight: 100,
+      color: theme.palette.common.black,
+      width: '450px'
+    }
+  }),
+
+  { name: 'Auth', index: 1 }
+);

--- a/src/components/Dashboard/Dashboard.jsx
+++ b/src/components/Dashboard/Dashboard.jsx
@@ -1,15 +1,11 @@
-import React, { memo, useCallback, useState, useEffect } from 'react';
-import { TextField, Button } from '@material-ui/core';
-import axios from 'axios';
-
+import React, { memo, useState, useEffect } from 'react';
 import useStyles from './styles';
 import DashboardElement from './DashboardElement';
-import { client } from 'fhirclient';
 const Dashboard = (props) => {
   const classes = useStyles();
   const [resources, setResources] = useState([]);
   const [message, setMessage] = useState("Loading...")
-  const addResources = useCallback((bundle)=>{
+  const addResources = (bundle)=>{
       if(bundle.entry){
           bundle.entry.forEach((e) => {
             const resource = e.resource;
@@ -18,12 +14,17 @@ const Dashboard = (props) => {
             }
           }) 
       }
-  })
+  }
   useEffect(() => {
-    props.client.patient.request('QuestionnaireResponse', {'pageLimit': 0, 'onPage': addResources}).then(() => {
-      setMessage("No QuestionnaireResponses Found for user with patientId: " + props.client.patient.id);
-    });
-  }, [])
+    if(props.client.patient.id) {
+      props.client.patient.request('QuestionnaireResponse', {'pageLimit': 0, 'onPage': addResources}).then(() => {
+        setMessage("No QuestionnaireResponses Found for user with patientId: " + props.client.patient.id);
+      });
+    } else {
+      setMessage("Invalid patient: No patientId provided")
+    }
+
+  }, [props.client.patient])
 
   return (
     <div className={classes.dashboardArea}>

--- a/src/components/Dashboard/Dashboard.jsx
+++ b/src/components/Dashboard/Dashboard.jsx
@@ -1,0 +1,38 @@
+import React, { memo, useCallback, useState, useEffect } from 'react';
+import { TextField, Button } from '@material-ui/core';
+import axios from 'axios';
+
+import useStyles from './styles';
+import DashboardElement from './DashboardElement';
+import { client } from 'fhirclient';
+const Dashboard = (props) => {
+  const classes = useStyles();
+  const [resources, setResources] = useState([]);
+  const [message, setMessage] = useState("Loading...")
+  const addResources = useCallback((bundle)=>{
+      if(bundle.entry){
+          bundle.entry.forEach((e) => {
+            const resource = e.resource;
+            if(resource.status === 'in-progress'){
+                setResources(resources => [...resources, resource])
+            }
+          }) 
+      }
+  })
+  useEffect(() => {
+    props.client.patient.request('QuestionnaireResponse', {'pageLimit': 0, 'onPage': addResources}).then(() => {
+      setMessage("No QuestionnaireResponses Found for user with patientId: " + props.client.patient.id);
+    });
+  }, [])
+
+  return (
+    <div className={classes.dashboardArea}>
+        {resources.length > 0?
+        resources.map((e) => {
+          return <DashboardElement key = {e.id} resource = {e}/>
+        }): <div>{message}</div>}
+    </div>
+  );
+};
+
+export default memo(Dashboard);

--- a/src/components/Dashboard/DashboardElement.jsx
+++ b/src/components/Dashboard/DashboardElement.jsx
@@ -1,6 +1,4 @@
-import React, { memo, useCallback, useState, useEffect } from 'react';
-import { TextField, Button } from '@material-ui/core';
-import axios from 'axios';
+import React, { memo } from 'react';
 
 import useStyles from './styles';
 const DashboardElement = (props) => {

--- a/src/components/Dashboard/DashboardElement.jsx
+++ b/src/components/Dashboard/DashboardElement.jsx
@@ -1,0 +1,18 @@
+import React, { memo, useCallback, useState, useEffect } from 'react';
+import { TextField, Button } from '@material-ui/core';
+import axios from 'axios';
+
+import useStyles from './styles';
+const DashboardElement = (props) => {
+  const classes = useStyles();
+  const resource = props.resource;
+
+  return (
+    <div className = {classes.dashboardElement}>
+        <div>ID:{resource.id}</div>
+        <div>Questionnaire: {resource.questionnaire}</div>
+    </div>
+  );
+};
+
+export default memo(DashboardElement);

--- a/src/components/Dashboard/styles.jsx
+++ b/src/components/Dashboard/styles.jsx
@@ -1,0 +1,35 @@
+import { makeStyles } from '@material-ui/core/styles';
+export default makeStyles(
+  theme => ({
+    adminBar: {
+      height: '95px',
+      backgroundColor: theme.palette.common.purple,
+      width: '100%',
+      textAlign: 'center',
+      lineHeight: '95px'
+    },
+    formFont: {
+      fontFamily: '"Gill Sans", sans-serif'
+    },
+    dashboardArea: {
+      backgroundColor: 'white',
+      margin: '80px',
+      padding: '20px'
+    },
+    dashboardElement: {
+      height: '100px',
+      width: '100%',
+      padding: '10px',
+      border: '1px solid black',
+      borderLeft: '3px solid #f50057',
+      margin: '5px',
+      backgroundColor: '#fafafa',
+      '&:hover': {
+        backgroundColor: '#fff'
+      }
+    },
+
+  }),
+
+  { name: 'Dashboard', index: 1 }
+);

--- a/src/containers/PatientPortal.jsx
+++ b/src/containers/PatientPortal.jsx
@@ -1,12 +1,9 @@
-import React, { memo, useCallback, useState, useEffect } from 'react';
-import { TextField, Button } from '@material-ui/core';
-import axios from 'axios';
+import React, { memo, useState, useEffect } from 'react';
 import useStyles from './styles/styles';
 import FHIR from "fhirclient";
 import config from '../properties.json';
 import Login from '../components/Auth/Login';
 import Dashboard from '../components/Dashboard/Dashboard';
-import theme from './styles/theme';
 const PatientPortal = () => {
     const classes = useStyles();
     const [token, setToken] = useState(null);

--- a/src/containers/PatientPortal.jsx
+++ b/src/containers/PatientPortal.jsx
@@ -1,0 +1,49 @@
+import React, { memo, useCallback, useState, useEffect } from 'react';
+import { TextField, Button } from '@material-ui/core';
+import axios from 'axios';
+import useStyles from './styles/styles';
+import FHIR from "fhirclient";
+import config from '../properties.json';
+import Login from '../components/Auth/Login';
+import Dashboard from '../components/Dashboard/Dashboard';
+import theme from './styles/theme';
+const PatientPortal = () => {
+    const classes = useStyles();
+    const [token, setToken] = useState(null);
+    const [client, setClient] = useState(null);
+
+    useEffect(() => {
+        if(token) {
+            const data = JSON.parse(Buffer.from(token.split('.')[1], 'base64'))
+            setClient(FHIR.client({
+                serverUrl: config.ehr_base,
+                tokenResponse: {
+                    type: 'bearer',
+                    access_token: token,
+                    patient: data.patientId
+                },
+              }));
+        }
+
+      }, [token])
+
+
+    return (
+        <div className={classes.background}>
+
+            <div className={classes.adminBar}>
+                <span className={classes.adminBarText}>
+                    <strong>REMS</strong> Patient Portal
+                </span>
+            </div>
+
+                {token && client ?
+                    <Dashboard client={client}></Dashboard>
+                    :
+                    <Login tokenCallback={setToken}></Login>
+                }
+        </div>
+    );
+};
+
+export default memo(PatientPortal);

--- a/src/containers/styles/styles.jsx
+++ b/src/containers/styles/styles.jsx
@@ -1,0 +1,28 @@
+import { makeStyles } from '@material-ui/core/styles';
+export default makeStyles(
+  theme => ({
+    background: {
+      backgroundColor: theme.palette.common.offWhite,
+      height: '100vh'
+    },
+    adminBar: {
+      height: '95px',
+      backgroundColor: theme.palette.common.redDark,
+      width: '100%',
+      textAlign: 'center',
+      lineHeight: '95px'
+    },
+    adminBarText: {
+      color: theme.palette.common.white,
+      fontSize: '19px',
+      fontFamily: 'Verdana',
+      float: 'left',
+      marginLeft: '20px'
+    },
+    formFont: {
+      fontFamily: '"Gill Sans", sans-serif'
+    },
+  }),
+
+  { name: 'PatientPortal', index: 1 }
+);

--- a/src/containers/styles/theme.jsx
+++ b/src/containers/styles/theme.jsx
@@ -1,4 +1,4 @@
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createTheme } from '@material-ui/core/styles';
 const colors = {
   white: '#fff',
   offWhite: '#f5f5fa',
@@ -92,7 +92,7 @@ const materialUiOverridesBase = {
   }
 };
 
-const theme = createMuiTheme({
+const theme = createTheme({
   palette: { ...paletteBase },
   overrides: { ...materialUiOverridesBase }
 });

--- a/src/containers/styles/theme.jsx
+++ b/src/containers/styles/theme.jsx
@@ -1,0 +1,100 @@
+import { createMuiTheme } from '@material-ui/core/styles';
+const colors = {
+  white: '#fff',
+  offWhite: '#f5f5fa',
+  black: '#222',
+  red: '#d95d77',
+  redDark: '#bb3551',
+  redLight: '#f50057',
+  blue: '#5d89a1',
+  blueDark: '#386883',
+  blueLighter: '#9ad2f0',
+  gray: '#4a4a4a',
+  grayMedium: '#676a70',
+  grayBlue: '#cbd5df',
+  grayBlueDark: '#7d8892',
+  grayHighlight: '#eaeaeb',
+  grayLight: '#4e5258',
+  grayLighter: '#b5b6ba',
+  grayLightest: '#f2f3f9',
+  grayDark: '#444',
+  grayVeryDark: '#3a3a3a',
+  grayLightText: '#87878e',
+  green: '#2fa874',
+  maroon: '#a83048',
+  purple: '#8b72d6',
+  turqoise: '#37c0ae',
+  turqoiseLight: '#e6f7f5'
+};
+
+const paletteBase = {
+  primary: {
+    main: colors.blue
+  },
+  secondary: {
+    main: colors.redLight
+  },
+  error: {
+    main: colors.red
+  },
+  common: colors,
+  background: {
+    default: colors.grayLightest,
+    primary: colors.grayLight
+  },
+  text: {
+    primary: colors.black,
+    secondary: colors.black,
+    gray: colors.grayLighter
+  },
+  grey: {
+    800: colors.gray
+  },
+  purple: {
+    main: colors.purple
+  }
+};
+
+const materialUiOverridesBase = {
+  MuiTableCell: {
+    body: {
+      color: '#575b62'
+    },
+    head: {
+      color: '#575b62',
+      fontWeight: '600',
+      fontSize: '12px'
+    },
+    sizeSmall: {
+      padding: '5px 24px 5px 16px',
+      '&:last-child': {
+        paddingRight: '0px',
+        width: '80px'
+      }
+    }
+  },
+  MuiTableContainer: {
+    root: {
+      width: '70vw',
+      margin: '0 20px 0 20px',
+      overflowY: 'visible',
+      overflowX: 'scroll',
+      backgroundColor: 'white'
+    }
+  },
+  MuiTableSortLabel: {
+    root: {
+      color: 'black',
+      '&$active': {
+        color: 'black'
+      }
+    }
+  }
+};
+
+const theme = createMuiTheme({
+  palette: { ...paletteBase },
+  overrides: { ...materialUiOverridesBase }
+});
+
+export default theme;


### PR DESCRIPTION
Make sure to use the patient-portal branch of the test-ehr with this.  You will have to load the keycloak json to get it to work.

This PR adds a patient portal endpoint at `/patient-portal`, a login UI and a viewer for the returned QuestionnaireResponses.   Changes to the keycloak server allow return of information like the patientId through the accessToken.  Using that, the patient portal allows users to login and then returns a list of only their in-progress QuestionnaireResponses.  

To test, ensure jonsnow has some in-progress QuestionnaireResponses in the EHR, then login as jonsnow in the patient-portal.  You should see the QuestionnaireResponses appear in the UI.  Future tasks will implement integration with DTR and interaction with the information, the goal of this task is simply creating the UI.

You can log in as other users besides jonsnow, but none of the currently established ones have an associated patientId.  Only jonsnow has an associated patient resources and accompanying medication request.  

To alter patients/users in keycloak, go to the users tab and select a user, then select the "attributes" tab.  You can change the `patientId` attribute to change what gets returned in the accessToken.  